### PR TITLE
Fix/GH-18 (#18)

### DIFF
--- a/config/blame.php
+++ b/config/blame.php
@@ -2,6 +2,7 @@
 
 // config for Kamansoft/LaravelBlame
 return [
+    'system_user_id' => env('BLAME_SYSTEM_USER_ID'),
     'system_user_name' => env('BLAME_SYSTEM_USER_NAME', 'system'),
     'system_user_email' => env('BLAME_SYSTEM_USER_EMAIL', 'system'.'@'.explode('/', config('app.url'))[2]),
     'created_by_field_name' => 'created_by',

--- a/config/private_blame.php
+++ b/config/private_blame.php
@@ -2,7 +2,7 @@
 
 //non publishable config files
 return [
-    'system_user_id' => env('BLAME_SYSTEM_USER_ID'), //do not modify this line
+    //'system_user_id' => env('BLAME_SYSTEM_USER_ID'), //do not modify this line
     'migration_name_prefix' => 'add_blaming_fields_to_',
     'migration_name_suffix' => '_table',
 

--- a/src/Traits/ModelBlamer.php
+++ b/src/Traits/ModelBlamer.php
@@ -36,7 +36,7 @@ trait ModelBlamer
             $to_return = Auth::user()->getKey();
         } else {
             Log::warning(static::class.' Not logged user using system user');
-            $to_return = env('BLAME_SYSTEM_USER_ID');
+            $to_return = config('blame.system_user_id');
         }
 
         return $to_return;


### PR DESCRIPTION
- Switch the getUserToBlamePk() to fallback as laravel config() instead of env() --> Following Laravel best practices
- Publish blame.system_user_id to the blame public config, so that it can be assigned a default value on a project-specific basis